### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/SECURITY_GROUP_INGRESS_REMEDIATION/parameters.json
+++ b/SECURITY_GROUP_INGRESS_REMEDIATION/parameters.json
@@ -2,7 +2,7 @@
   "Version": "1.0",
   "Parameters": {
     "RuleName": "SECURITY_GROUP_INGRESS_REMEDIATION",
-    "SourceRuntime": "python3.7",
+    "SourceRuntime": "python3.10",
     "CodeKey": "SECURITY_GROUP_INGRESS_REMEDIATION.zip",
     "InputParameters": "{}",
     "OptionalParameters": "{}",


### PR DESCRIPTION
CloudFormation templates in aws-blog-security-group-ingress-remediation have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.